### PR TITLE
Update config/public/wp-config.php

### DIFF
--- a/config/public/wp-config.php
+++ b/config/public/wp-config.php
@@ -13,7 +13,9 @@
  *
  * @package WordPress
  */
-
+ 
+define('WP_HOME', "http://{$_SERVER["HTTP_HOST"]}");
+define('WP_SITEURL', "http://{$_SERVER["HTTP_HOST"]}");
 
 $url = parse_url(getenv("CLEARDB_DATABASE_URL"));
 
@@ -33,6 +35,9 @@ define("DB_PASSWORD", trim($url["pass"]));
 /** MySQL hostname */
 define("DB_HOST", trim($url["host"]));
 // define("DB_HOST", "us-cdbr-east-03.cleardb.com");
+
+/** MySQL hostname */
+define("DB_PORT", trim($url["port"]));
 
 /** Database Charset to use in creating database tables. */
 define("DB_CHARSET", "utf8");


### PR DESCRIPTION
Great and extremely useful project!

Here is a proposal to add some variables/settings to the wp-config - that i lost upon updating today, and that i know i'll be using on every project to allow running this wordpress install locally for development.

*\* Add variables to override the wordpress hostnames in the database.
**Add 'DB_PORT' to allow for nonstandard mysql ports for production and development.

(side note:  how do you use this project setup locally to develop?   i just copied in the whole wordpress install, but that seems not ideal.)
