### PR TITLE
Rewrite herokuapp.com url to stop duplicate content

### DIFF
--- a/config/vendor/nginx/conf/wordpress.conf.erb
+++ b/config/vendor/nginx/conf/wordpress.conf.erb
@@ -62,6 +62,13 @@ server {
   #   deny            all;
   # }
 
+  # Rewrite herokuapp.com url to stop duplicate content
+  # Uncomment and edit as required
+  # if ($host ~* "^yourblog.herokuapp.com$") {
+  #   rewrite ^(.*)$ http://blog.yourdomain.com$1 permanent;
+  #   break;
+  # }
+  
   # Set a variable to work around the lack of nested conditionals
   set $cache_uri $request_uri;
 


### PR DESCRIPTION
This should stop Google (and other crawlers) being able to access the xxx.herokuapp.com url and penalising it for duplicate content.
