### PR TITLE
Disable automatic updates

### DIFF
--- a/config/public/wp-config.php
+++ b/config/public/wp-config.php
@@ -111,6 +111,11 @@ define("WP_CACHE", getenv("WP_CACHE") == "true");
  */
 define("DISABLE_WP_CRON", getenv("DISABLE_WP_CRON") == "true");
 
+/**
+ * Disable automatic updates, they won't survive restarting and scaling dynos
+ */
+define( 'AUTOMATIC_UPDATER_DISABLED', true );
+
 /* That"s all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
Disable automatic updates that are already on by default for minor releases in WP 3.7. Updates won't survive restarting and scaling dynos.
