### PR TITLE
Make the wordpress block the auto-updates

### DIFF
--- a/config/public/wp-config.php
+++ b/config/public/wp-config.php
@@ -111,6 +111,17 @@ define("WP_CACHE", getenv("WP_CACHE") == "true");
  */
 define("DISABLE_WP_CRON", getenv("DISABLE_WP_CRON") == "true");
 
+/**
+* Disable the core update
+*/
+define( 'WP_AUTO_UPDATE_CORE', false );
+
+/**
+* Disable plugin update
+*/
+define('WP_HTTP_BLOCK_EXTERNAL', true);
+define('WP_ACCESSIBLE_HOSTS', 'amazonaws.com');
+
 /* That"s all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
In your todo list of the [heroku-buildpack-wordpress](https://github.com/mchung/heroku-buildpack-wordpress) you are asking to let the end-user not do what it shouldn't. 

One main part that I needed for my project is to block the auto-updates of end-users. I've done it in this branch by modifying the wp-config.php file. I'm using it on my main site and I have some themes that should warn me about the updates and do not. I do not have to overwrite the css to hide updates buttons has they do say they are up to date.

The most important thing when blocking the plug-ins is to allow the one we want to communicate to external http. In this file there is only `define('WP_ACCESSIBLE_HOSTS', 'amazonaws.com');` but I added access to my piwik site also. This part must be modified depending of the plug-ins used.
