### PR TITLE
Make WP_SITEURL smart by detecting if $WORDPRESS_DIR is set

### DIFF
--- a/config/public/wp-config.php
+++ b/config/public/wp-config.php
@@ -39,9 +39,14 @@ define("DB_HOST", trim($url["host"]));
 
 /** Database Charset to use in creating database tables. */
 define("DB_CHARSET", "utf8");
+/** Support WORDPRESS_DIR */
+$siteurl = getenv("WORDPRESS_DIR");
 
 /** Allows both foobar.com and foobar.herokuapp.com to load media assets correctly. */
-define("WP_SITEURL", "http://" . $_SERVER["HTTP_HOST"]);
+if (!empty($siteurl))
+  define("WP_SITEURL", "http://" . $_SERVER["HTTP_HOST"] . "/" . $siteurl);
+else
+  define("WP_SITEURL", "http://" . $_SERVER["HTTP_HOST"]);
 
 /** WP_HOME is your Blog Address (URL). */
 // define('WP_HOME', "http://" . $_SERVER["HTTP_HOST"]);


### PR DESCRIPTION
Happy to see that the buildpack supports subdirectory (mchung/heroku-buildpack-wordpress/issues/23).

This patch instructs Wordpress to detect WORDPRESS_DIR and then dynamically sets WP_SITEURL. Currently, this isn't done, so when a developer sets WORDPRESS_DIR via `heroku config:set`, the site breaks since WP is still serving content out of the previously configured directory. And since the site breaks, the user can't login to update that variable. 

The buildpack README also specifies that WP_CONTENT_DIR and WP_CONTENT_URL must be set, however I didn't observe any problems without them set. Is that doc out of date? Or was I just lucky?

cc: @okko
