### PR TITLE
Fix $_SERVER['SERVER_NAME'] and $_SERVER['PORT']

### DIFF
--- a/config/vendor/nginx/conf/wordpress.conf.erb
+++ b/config/vendor/nginx/conf/wordpress.conf.erb
@@ -112,5 +112,7 @@ server {
     include         /app/vendor/nginx/conf/fastcgi_params;
     fastcgi_pass    unix:/tmp/php-fpm.socket;
     fastcgi_param   SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param   SERVER_PORT 80;
+    fastcgi_param   SERVER_NAME $host;
   }
 }


### PR DESCRIPTION
Those php variables were returning "localhost" and the env heroku variable $PORT, so plugins using them to build URLs were not working. Those two lines fix the problem.
