### PR TITLE
Update WP Read-Only (fixes broken image editor)

### DIFF
--- a/config/vendor/nginx/conf/nginx.conf
+++ b/config/vendor/nginx/conf/nginx.conf
@@ -54,5 +54,8 @@ http {
   set_real_ip_from    198.41.128.0/17;
   real_ip_header      X-Forwarded-For;
 
+  # should be same as upload_max_filesize in php.ini
+  client_max_body_size  2m;
+
   include wordpress.conf;
 }


### PR DESCRIPTION
Fixes an issue where, after editing and saving an image using the WordPress image editor, the edited file was not made available on S3. 

Also fixes an issue where temporary directories weren't being removed after assets are transferred to S3.
